### PR TITLE
fix: use `mtime` for last modified custom metadata

### DIFF
--- a/app/api/bucket/[bucket]/route.ts
+++ b/app/api/bucket/[bucket]/route.ts
@@ -2,6 +2,12 @@ import { getBucketFromEnv } from '@/utils/r2';
 
 export const runtime = 'edge';
 
+export type FileInfo = {
+	bucket: string;
+	key: string;
+	lastMod?: number;
+};
+
 export const PUT = async (
 	req: Request,
 	{ params: { bucket: bucketName } }: { params: { bucket: string } },
@@ -18,7 +24,7 @@ export const PUT = async (
 	const formData = await req.formData();
 
 	for (const [rawFileInfo, file] of formData) {
-		let fileInfo: { bucket: string; key: string; lastmod?: number };
+		let fileInfo: FileInfo;
 		try {
 			const parsedInfo = JSON.parse(atob(rawFileInfo));
 			if (
@@ -43,7 +49,7 @@ export const PUT = async (
 				httpMetadata: {
 					contentType: asFile.type,
 				},
-				customMetadata: fileInfo.lastmod ? { lastmod: fileInfo.lastmod?.toString() } : {},
+				customMetadata: fileInfo.lastMod ? { mtime: fileInfo.lastMod?.toString() } : {},
 			});
 		} catch (e) {
 			const msg = e instanceof Error ? e.message : 'Failed to upload file to bucket';

--- a/components/file-upload/upload-file-row.tsx
+++ b/components/file-upload/upload-file-row.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { bytesToString } from '@/utils';
+import type { FileInfo } from '@/app/api/bucket/[bucket]/route';
 import { UploadSimple } from '../icons';
 
 type Props = {
@@ -74,13 +75,14 @@ export const UploadFileRow = ({ bucket, dirPath, file }: Props) => {
 		const reqInstance = req.current;
 
 		const key = `${dirPath}/${file.name}`.replace(/\/+/g, '/').replace(/^\//, '');
-		const fileInfo = btoa(JSON.stringify({ bucket, key, lastMod: file.lastModified }));
+		const fileInfo: FileInfo = { bucket: bucket as string, key, lastMod: file.lastModified };
+		const fileInfoStr = btoa(JSON.stringify(fileInfo));
 
 		reqInstance?.open('PUT', `/api/bucket/${bucket}`);
 		reqInstance?.setRequestHeader('x-content-type', file.type);
 
 		const formData = new FormData();
-		formData.append(fileInfo, file);
+		formData.append(fileInfoStr, file);
 		reqInstance?.send(formData);
 	}, [bucket, dirPath, file]);
 

--- a/components/files-view/bucket-file-row.tsx
+++ b/components/files-view/bucket-file-row.tsx
@@ -62,9 +62,9 @@ export const BucketFileRow = ({ bucketName, path, type, file }: Props): JSX.Elem
 
 			<td>{type === 'file' ? bytesToString(file.size) : ''}</td>
 
-			<td>
-				{type === 'file' && file.customMetadata?.['lastmod']
-					? new Date(file.customMetadata['lastmod']).toLocaleString()
+			<td suppressHydrationWarning>
+				{type === 'file' && file.customMetadata?.['mtime']
+					? new Date(Number(file.customMetadata['mtime'])).toLocaleString()
 					: ''}
 			</td>
 		</tr>


### PR DESCRIPTION
This PR does the following:
- Uses `mtime` in the custom metadata for the last modified time.

Note that this is the field that rclone uses.